### PR TITLE
fix(indexer): replaced panic with error logging and cool down

### DIFF
--- a/apps/indexer/src/config.rs
+++ b/apps/indexer/src/config.rs
@@ -16,6 +16,12 @@ pub struct ChainConfig {
     /// For auto withdraw
     pub account_address: Option<String>,
     pub account_private_key: Option<String>,
+    #[serde(default="cooling_down_default")]
+    pub cooling_down: u64,
+}
+
+const fn cooling_down_default() -> u64 {
+    20
 }
 
 ///


### PR DESCRIPTION
This PR replaced `panic` by error logging and cool down to ensure that blockchain indexing chain will not be stopped in case of error.
